### PR TITLE
Portability fixes

### DIFF
--- a/simulation/main.R
+++ b/simulation/main.R
@@ -52,6 +52,9 @@ for(i in BM){
                  save.path=file.path(sim.dir, type),
                  mc.preschedule = FALSE)
         dats <- load.fix(file.path(sim.dir, type), bd=tree)
+        if( ! file.exists( sim.dir ) ) {
+            dir.create( sim.dir, recursive=TRUE )
+        }
         save(dats, file=file.path(sim.dir, sprintf('%s.Rdata', type)))
     }
 }

--- a/simulation/main.R
+++ b/simulation/main.R
@@ -1,7 +1,7 @@
-rm(list=ls())
+#rm(list=ls())
 ## change to your working directory, i.e., whever the github
 ## repository was cloned
-setwd('~/Dropbox/network_assembly')
+setwd('~/pkg/network_assembly')
 
 tree <- 'bd'
 

--- a/simulation/src/all/SimTreeTrait.R
+++ b/simulation/src/all/SimTreeTrait.R
@@ -120,11 +120,11 @@ interact.phylo.signal <- function(dist.tree, int.mat,
                 options(warn=-1)
                 cor.plant <- mantel(plant.dist,
                                     dist.tree2,
-                                    permutations=FALSE,
+                                    permutations=0,
                                     method=cor.method)$statistic
                 cor.pol <- mantel(pol.dist,
                                   dist.tree1,
-                                  permutations=FALSE,
+                                  permutations=0,
                                   method=cor.method)$statistic
                 ## subtrack 1 from dissimilarity to get simmilarity
                 return(c(cor.pol=cor.pol,

--- a/simulation/src/bd/bdMaster.R
+++ b/simulation/src/bd/bdMaster.R
@@ -19,6 +19,9 @@ run.sim <- function(prms, i, save.path) {
     print(i)
     sim.links <- lapply(1:prms$ntree, f)
     res <- list(prms= prms, sim.links= sim.links)
+    if( ! file.exists( save.path ) ) {
+        dir.create( save.path, recursive=TRUE )
+    }
     save(res, file= file.path(save.path, sprintf('%d.RData', i)))
 }
 

--- a/simulation/src/coal/CoalMaster.R
+++ b/simulation/src/coal/CoalMaster.R
@@ -11,5 +11,8 @@ run.sim <- function(prms, i, save.path) {
   }
   sim.links <- lapply(1:prms$ntree, f)
   res <- list(prms= prms, sim.links= sim.links)
+  if( ! file.exists( save.path ) ) {
+    dir.create( save.path, recursive=TRUE )
+  }
   save(res, file= file.path(save.path, sprintf('%d.RData', 22036+i)))
 }


### PR DESCRIPTION
Small fixes for portability :

* mantel() wants the permutations argument to be an integer, and won't coerce a Boolean. :-( 
* Create output directories if they don't already exist.
* Don't clobber the local environment.